### PR TITLE
Added tensorboard image logging

### DIFF
--- a/lab/logger/artifacts.py
+++ b/lab/logger/artifacts.py
@@ -102,23 +102,26 @@ class _Collection(Artifact, ABC):
     def keys(self):
         return self._values.keys()
 
+    def get_value(self, key: str):
+        return self._values[key]
 
 class Image(_Collection):
     def get_print_length(self) -> Optional[int]:
         return None
 
     def print_all(self, others: Dict[str, Artifact]):
-        images = [_to_numpy(v) for v in self._values.values()]
-        cols = 3
-        fig: plt.Figure
-        fig, axs = plt.subplots((len(images) + cols - 1) // cols, cols,
-                                sharex='all', sharey='all',
-                                figsize=(8, 10))
-        fig.suptitle(self.name)
-        for i, img in enumerate(images):
-            ax: plt.Axes = axs[i // cols, i % cols]
-            ax.imshow(img)
-        plt.show()
+        if self.is_print:
+            images = [_to_numpy(v) for v in self._values.values()]
+            cols = 3
+            fig: plt.Figure
+            fig, axs = plt.subplots((len(images) + cols - 1) // cols, cols,
+                                    sharex='all', sharey='all',
+                                    figsize=(8, 10))
+            fig.suptitle(self.name)
+            for i, img in enumerate(images):
+                ax: plt.Axes = axs[i // cols, i % cols]
+                ax.imshow(img)
+            plt.show()
 
 
 class Text(_Collection):
@@ -126,9 +129,10 @@ class Text(_Collection):
         return None
 
     def print_all(self, others: Dict[str, Artifact]):
-        logger.log(self.name, TextStyle.heading)
-        for t in self._values.values():
-            logger.log(t, TextStyle.value)
+        if self.is_print:
+            logger.log(self.name, TextStyle.heading)
+            for t in self._values.values():
+                logger.log(t, TextStyle.value)
 
 
 class IndexedText(_Collection):


### PR DESCRIPTION
Hi. I've seen that the `Artifact` class is used to print outputs during training time. I usually keep track of outputs during training. I added support in tensorboard for image artifact logging.

What I did is checking the `is_print` value is true while the `print_all` method is called. This is to avoid unnecessary outputs. Then, in the tensorboard writer, I iterate over `Image` artifacts and write them using `tf.summary.image`. The method should be extensible seamlessly to other artifact types.

I assume that artifacts are flushed once they are printed or overlapped, so this won't create memory issues during training. Am I wrong?